### PR TITLE
feat(MeetingsAdapter): define adapter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,7 +46,8 @@
         "allowUnboundThis": true
       }
     ],
-    "require-jsdoc": "off"
+    "require-jsdoc": 2,
+    "valid-jsdoc": "off"
   },
   "overrides": [
     {

--- a/src/MeetingsAdapter.js
+++ b/src/MeetingsAdapter.js
@@ -1,0 +1,73 @@
+import {throwError} from 'rxjs';
+
+import WebexAdapter from './WebexAdapter';
+
+/**
+ * A meeting object that allows users to have a WebRTC meeting.
+ *
+ * @typedef {Object}  Meeting
+ * @property {string}            ID The meeting identifier.
+ * @property {string}            title The title of the meeting.
+ * @property {string}            startTime The time and date of the start of the meeting. Must be a valid date-time string.
+ * @property {string}            endTime The time and date of the end of the meeting. Must be a valid date-time string.
+ * @property {MediaStreamTrack}  localVideo The local video stream track.
+ * @property {MediaStreamTrack}  localAudio The local audio stream track.
+ * @property {MediaStream}       localShare The local media share stream.
+ * @property {MediaStreamTrack}  remoteVideo The remote video stream track.
+ * @property {MediaStreamTrack}  remoteAudio The remote audio stream track.
+ * @property {MediaStream}       remoteShare The remote media share stream.
+ */
+
+/**
+ * The control that may modify a meeting or meeting state.
+ *
+ * @typedef {Object}  MeetingControl
+ * @property {string}    ID The meeting control ID or name.
+ * @property {string}    alt The text to display when user hovers over control.
+ * @property {function}  action A function that performs the control action. Must return a `MeetingControlState` value.
+ * @property {string}    icon Momentum-ui icon name to display for the meeting control.
+ * @property {string}    text Text to display on the meeting control. If there is an icon and text, text takes precedence.
+ */
+
+/**
+ * Enum for meeting control states.
+ *
+ * @readonly
+ * @enum {string}
+ */
+export const MeetingControlState = {
+  ACTIVE: 'active',
+  INACTIVE: 'inactive',
+  DISABLED: 'disabled',
+};
+
+/**
+ * This is a base class that defines the interface that maps meetings data.
+ * Developers that want to extend `MeetingsAdapter` must implement all of its methods,
+ * adhering to the exact parameters and structure of the returned objects.
+ */
+export default class MeetingsAdapter extends WebexAdapter {
+  /**
+   * Creates a new instance of the MeetingsAdapter.
+   *
+   * @param {Object} datasource The primary datasource the adapter will be using.
+   */
+  constructor(datasource) {
+    super(datasource);
+
+    this.meetingControls = {};
+  }
+
+  /**
+   * Returns an observable that emits a Meeting object.
+   * Whenever there is an update to the meeting, the observable
+   * will emit a new updated Meeting object, if datasource permits.
+   *
+   * @param {string} ID  ID of the meeting to get.
+   * @returns {Observable.<Meeting>}
+   * @memberof MeetingsAdapter
+   */
+  getMeeting(ID) {
+    return throwError(new Error('getMeeting(ID) must be defined in MeetingsAdapter'));
+  }
+}

--- a/src/MeetingsAdapter.test.js
+++ b/src/MeetingsAdapter.test.js
@@ -1,0 +1,33 @@
+import {isObservable} from 'rxjs';
+
+import MeetingsAdapter from './MeetingsAdapter';
+
+describe('Meetings Adapter Interface', () => {
+  let meetingsAdapter;
+
+  beforeEach(() => {
+    meetingsAdapter = new MeetingsAdapter();
+  });
+
+  test('getMeeting() returns an observable', () => {
+    expect(isObservable(meetingsAdapter.getMeeting())).toBeTruthy();
+  });
+
+  test('getMeeting() errors because it needs to be defined', (done) => {
+    meetingsAdapter.getMeeting('msgID').subscribe(
+      () => {},
+      (error) => {
+        expect(error.message).toBe('getMeeting(ID) must be defined in MeetingsAdapter');
+        done();
+      }
+    );
+  });
+
+  test('meetingControls property exists', () => {
+    expect(meetingsAdapter).toHaveProperty('meetingControls');
+  });
+
+  afterEach(() => {
+    meetingsAdapter = null;
+  });
+});

--- a/src/WebexAdapter.js
+++ b/src/WebexAdapter.js
@@ -1,3 +1,6 @@
+/**
+ * This is a base class that defines the interface that other adapter interfaces extend.
+ */
 export default class WebexAdapter {
   /**
    * Creates a new instance of the WebexAdapter.

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export {default as WebexAdapter} from './WebexAdapter';
 export {default as ActivitiesAdapter} from './ActivitiesAdapter';
+export {default as MeetingsAdapter, MeetingControlState} from './MeetingsAdapter';
 export {default as PeopleAdapter, PersonStatus} from './PeopleAdapter';
 export {default as RoomsAdapter, RoomType} from './RoomsAdapter';


### PR DESCRIPTION
Diverged slightly from https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-99431 as noted via PR comments.

Omitted the `createMeeting(destinationType, destinationID)` function after discussions with the team that the ID will be something the implementation will know how to handle. `getMeeting` should always return a meeting, the interface doesn't need to know if it is creating one or returning an existing one.