### PR TITLE
build(workflow): dispatch event for new version for widget

### DIFF
--- a/.github/workflows/dispatch-new-version-event.yml
+++ b/.github/workflows/dispatch-new-version-event.yml
@@ -27,4 +27,9 @@ jobs:
               -H 'Accept: application/vnd.github.everest-preview+json' \
               -u ${{ secrets.ACCESS_TOKEN }} \
               --data '{"event_type": "component-adapter-interfaces:version-changed", "client_payload": { "version": "'"${CURRENT_VERSION}"'"}'
+
+              curl -X POST https://api.github.com/repos/webex/widgets/dispatches \
+              -H 'Accept: application/vnd.github.everest-preview+json' \
+              -u ${{ secrets.ACCESS_TOKEN }} \
+              --data '{"event_type": "component-adapter-interfaces:version-changed", "client_payload": { "version": "'"${CURRENT_VERSION}"'"}'
           fi


### PR DESCRIPTION
As we include interfaces as a dependency for widgets we need also to add the workflow for this.
https://github.com/webex/widgets/pull/55/commits/ad783316afe5423ea4a2dba141d7bcaa98063790