### PR TITLE
feat(MeetingsAdapter): transform localAudio, localShare and localVideo into objects

### DIFF
--- a/src/MeetingsAdapter.js
+++ b/src/MeetingsAdapter.js
@@ -10,25 +10,26 @@ import WebexAdapter from './WebexAdapter';
  */
 
 /**
- * MediaStreamTrack is a Web API standard that represents a single media track within a stream.
+ * An object that represents a media stream and its permission with respect to a meeting.
  *
- * @external MediaStreamTrack
- * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack}
+ * @typedef {object}  MeetingStream
+ * @property {MediaStream}      stream      The local media stream
+ * @property {MediaPermissions} permission  The state of the user permission on local media @see {@link MediaPermissions} enum
  */
 
 /**
  * A meeting object that allows users to have a WebRTC meeting.
  *
  * @typedef {object}  Meeting
- * @property {string}            ID           The meeting identifier
- * @property {string}            title        The title of the meeting
- * @property {MediaStreamTrack}  localVideo   The local video stream track
- * @property {MediaStreamTrack}  localAudio   The local audio stream track
- * @property {MediaStream}       localShare   The local media share stream
- * @property {MediaStream}       remoteVideo  The remote video stream
- * @property {MediaStream}       remoteAudio  The remote audio stream
- * @property {MediaStream}       remoteShare  The remote media share stream
- * @property {MeetingState}      state        The state of the meeting
+ * @property {string}        ID           The meeting identifier
+ * @property {string}        title        The title of the meeting
+ * @property {MeetingStream} localVideo   The local video information
+ * @property {MeetingStream} localAudio   The local audio information
+ * @property {MeetingStream} localShare   The local share information
+ * @property {MediaStream}   remoteVideo  The remote video stream
+ * @property {MediaStream}   remoteAudio  The remote audio stream
+ * @property {MediaStream}   remoteShare  The remote media share stream
+ * @property {MeetingState}  state        The state of the meeting
  */
 
 /**


### PR DESCRIPTION
Transform localVideo, localShare and localAudio into objects containing "stream" and "permission". Create a new object definition 

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-249784