### PR TITLE
feat(RoomsAdapter): update room adapter method names

### DIFF
--- a/src/RoomsAdapter.js
+++ b/src/RoomsAdapter.js
@@ -59,22 +59,22 @@ export default class RoomsAdapter extends WebexAdapter {
    * @returns {external:Observable.<Array.<string|ActivityDate>>} Observable stream that emits arrays of activity IDs
    * @memberof RoomsAdapter
    */
-  getRoomActivities(ID) {
-    return throwError(new Error('getRoomActivities(ID) must be defined in RoomsAdapter'));
+  getActivitiesInRealTime(ID) {
+    return throwError(new Error('getActivitiesInRealTime(ID) must be defined in RoomsAdapter'));
   }
 
   /**
    * Returns an observable that emits an array of the next chunk of previous
    * activity data of the given roomID. If `hasMoreActivities` returns false,
    * the observable will complete.
-   * **Previous activity data must be sorted newest-to-oldest.**
+   * **Past activity data must be sorted newest-to-oldest.**
    *
    * @param {string} ID  ID of the room for which to get activities.
    * @returns {external:Observable.<Array.<string|ActivityDate>>} Observable stream that emits arrays of activity IDs
    * @memberof RoomsAdapter
    */
-  getPreviousRoomActivities(ID) {
-    return throwError(new Error('getPreviousRoomActivities(ID) must be defined in RoomsAdapter'));
+  getPastActivities(ID) {
+    return throwError(new Error('getPastActivities(ID) must be defined in RoomsAdapter'));
   }
 
   /**

--- a/src/RoomsAdapter.test.js
+++ b/src/RoomsAdapter.test.js
@@ -29,32 +29,32 @@ describe('Rooms Adapter Interface', () => {
     });
   });
 
-  describe('getRoomActivities()', () => {
+  describe('getActivitiesInRealTime()', () => {
     test('returns an observable', () => {
-      expect(isObservable(roomsAdapter.getRoomActivities())).toBeTruthy();
+      expect(isObservable(roomsAdapter.getActivitiesInRealTime())).toBeTruthy();
     });
 
     test('errors because it needs to be defined', (done) => {
-      roomsAdapter.getRoomActivities('id').subscribe(
+      roomsAdapter.getActivitiesInRealTime('id').subscribe(
         () => {},
         (error) => {
-          expect(error.message).toBe('getRoomActivities(ID) must be defined in RoomsAdapter');
+          expect(error.message).toBe('getActivitiesInRealTime(ID) must be defined in RoomsAdapter');
           done();
         },
       );
     });
   });
 
-  describe('getPreviousRoomActivities()', () => {
+  describe('getPastActivities()', () => {
     test('returns an observable', () => {
-      expect(isObservable(roomsAdapter.getRoomActivities())).toBeTruthy();
+      expect(isObservable(roomsAdapter.getActivitiesInRealTime())).toBeTruthy();
     });
 
     test('errors because it needs to be defined', (done) => {
-      roomsAdapter.getPreviousRoomActivities('id').subscribe(
+      roomsAdapter.getPastActivities('id').subscribe(
         () => {},
         (error) => {
-          expect(error.message).toBe('getPreviousRoomActivities(ID) must be defined in RoomsAdapter');
+          expect(error.message).toBe('getPastActivities(ID) must be defined in RoomsAdapter');
           done();
         },
       );


### PR DESCRIPTION
Updating names in RoomsAdapter:
- getRoomActivities -> getActivitiesInRealTime
- getPreviousRoomActivities -> getPastActivities

[SPARK-302946](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-302946)